### PR TITLE
MIDI and OSD additions - WIP

### DIFF
--- a/addons.make
+++ b/addons.make
@@ -1,2 +1,3 @@
+ofxMidi
 ofxOsc
 ofxLua

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@
 #include "ofApp.h"
 
 int main() {
-    ofSetupOpenGL(1920, 1080, OF_FULLSCREEN);
-    //ofSetupOpenGL(1280, 720, OF_FULLSCREEN);
-    ofRunApp(new ofApp());
+	ofSetupOpenGL(1920, 1080, OF_FULLSCREEN);
+//	ofSetupOpenGL(1280, 720, OF_FULLSCREEN);
+	ofRunApp(new ofApp());
 }

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -10,245 +10,449 @@
 
 //--------------------------------------------------------------
 void ofApp::setup() {
-    
-    // listen on the given port
-    cout << "listening for osc messages on port " << PORT << "\n";
-    receiver.setup(PORT);    
-    
-    ofSetVerticalSync(true);
-    ofSetFrameRate(60);
-    ofSetLogLevel("ofxLua", OF_LOG_VERBOSE);
 
-    ofHideCursor();
+	// Workaround for "other" sized screens/displays
+	ofSetWindowShape(ofGetWidth(), ofGetHeight());
+	ofSetWindowPosition(0, 0);
 
-    ofSetBackgroundColor(0,0,0);
-        
-    // setup audio
-    soundStream.printDeviceList();
-    
-    int bufferSize = 256;
+	// listen on the given port
+	cout << "listening for osc messages on port " << PORT << "\n";
+	receiver.setup(PORT);	
+	
+	//ofSetVerticalSync(true); // this will force to 60 fps
+	ofSetFrameRate(30);
+	ofSetLogLevel("ofxLua", OF_LOG_VERBOSE);
 
-    left.assign(bufferSize, 0.0);
-    right.assign(bufferSize, 0.0);
-    
-    bufferCounter    = 0;
+	ofHideCursor();
 
-    ofSoundStreamSettings settings;
-    
-    // device by name
-    auto devices = soundStream.getMatchingDevices("default");
-    if(!devices.empty()){
-        settings.setInDevice(devices[0]);
-    }
+	ofSetBackgroundColor(0,0,0);
 
-    settings.setInListener(this);
+	// GPIO
+    //gpio25.setup(GPIO24,IN,LOW);
+	//gpio25.export_gpio();
+	//lua.setNumber("button2", 0);
+	
+	// MIDI
+	// print input ports to console
+	midiIn.listInPorts();
+	
+	// Open a MIDI Port
+		//midiIn.openPort(0); // open port by number (you may need to change this)
+		//midiIn.openPort("IAC Pure Data In");	// by name
+		midiIn.openVirtualPort("ofxMidiIn Input"); // open a virtual port
+	
+		// don't ignore sysex, timing, & active sense messages (midiSysex, midiTiming, midiSense),
+		// these are ignored by default
+		//midiIn.ignoreTypes(false, false, false);
+	
+	// add ofApp as a listener
+	midiIn.addListener(this);
+	
+	// print received messages to the console
+	//midiIn.setVerbose(true);
+
+
+	// AUDIO Setup 
+	soundStream.printDeviceList();
+	
+	int bufferSize = 256;
+
+	left.assign(bufferSize, 0.0);
+	right.assign(bufferSize, 0.0);
+	
+	bufferCounter	= 0;
+
+	ofSoundStreamSettings settings;
+	
+	// device by name
+	auto devices = soundStream.getMatchingDevices("default");
+	if(!devices.empty()){
+		settings.setInDevice(devices[0]);
+	}
+
+	settings.setInListener(this);
     settings.sampleRate = 11025;
     settings.numOutputChannels = 0;
     settings.numInputChannels = 2;
     settings.bufferSize = bufferSize;
-    soundStream.setup(settings);    
+    soundStream.setup(settings);
+
 
     //some path, may be absolute or relative to bin/data
     string path = "/sdcard/Modes/oFLua"; 
     ofDirectory dir(path);
     dir.listDir();
 
-    //go through and print out all the paths
-    for(int i = 0; i < dir.size(); i++){
-        ofLogNotice(dir.getPath(i) + "/main.lua");
-        scripts.push_back(dir.getPath(i) + "/main.lua");
-    }
-        
-    // scripts to run
-    currentScript = 0;
-    
-    // init the lua state
-    lua.init(true); // true because we want to stop on an error
-    
-    // listen to error events
-    lua.addListener(this);
-    
-    // run a script
-    // true = change working directory to the script's parent dir
-    // so lua will find scripts with relative paths via require
-    // note: changing dir does *not* affect the OF data path
-    lua.doScript(scripts[currentScript], true);
-    
-    // call the script's setup() function
-    lua.scriptSetup();
+	//go through and print out all the paths
+	for(int i = 0; i < dir.size(); i++){
+		if (dir.doesDirectoryExist(dir.getPath(i))) {
+			ofLogNotice(dir.getPath(i) + "/main.lua");
+			scripts.push_back(dir.getPath(i) + "/main.lua");
+		}
+	}
 
-	// clear main screen
-	ofClear(0,0,0);
+	persistSetting = 0;
+	osdSetting = false;
+	osdShiftSetting = false;
+	
+	// scripts to run
+	currentScript = 0;
+	
+	// init the lua state
+	lua.init(true); // true because we want to stop on an error
+	
+	// listen to error events
+	lua.addListener(this);
+
+	lua.setBool("osd_state", false);
+	lua.setBool("osd_shift", false);
+	
+	// run a script
+	// true = change working directory to the script's parent dir
+	// so lua will find scripts with relative paths via require
+	// note: changing dir does *not* affect the OF data path
+	lua.doScript(scripts[currentScript]);  //lua.doScript(scripts[currentScript], true);
+	
+	// call the script's setup() function
+	lua.scriptSetup();
 }
 
 //--------------------------------------------------------------
 void ofApp::update() {
+	//gpio25.getval_gpio(state_button2);
+	//lua.setNumber("button2", state_button2);
+	
+	// Check for MIDI Messages and set lua table
+    while (!midiMessages.empty()) {
+    	lua.pushTable("midi_msg");
+    	
+        // printf("%lu messages to process.\n", midiMessages.size());
+        ofxMidiMessage message = midiMessages.front();
 
-    // check for waiting messages
-    while(receiver.hasWaitingMessages()){
-        // get the next message
-        ofxOscMessage m;
-        receiver.getNextMessage(m);
-        //cout << "new message on port " << PORT << m.getAddress() << "\n";
-        if(m.getAddress() == "/key") {   
-            if (m.getArgAsInt32(0) == 4 && m.getArgAsInt32(1) > 0) {
-                cout << "back" << "\n";
-                prevScript();
-            }
-            if (m.getArgAsInt32(0) == 5 && m.getArgAsInt32(1) > 0) {
-                cout << "fwd" << "\n";
-                nextScript();
-            }
-            if (m.getArgAsInt32(0) == 9 && m.getArgAsInt32(1) > 0) {
-                img.grabScreen(0,0,ofGetWidth(),ofGetHeight());
-                string fileName = "snapshot_"+ofToString(10000+snapCounter)+".png";
-                cout << "saving " + fileName + "...";
-                img.save("/sdcard/Grabs/" + fileName);
-                cout << "saved\n";
-                snapCounter++;
-            }
-            if (m.getArgAsInt32(0) == 10 && m.getArgAsInt32(1) > 0) {
-                cout << "trig" << "\n";
-                lua.setBool("trig", true);
-            }
-			if (m.getArgAsInt32(0) == 3 && m.getArgAsInt32(1) > 0) {
-            	cout << "change persist" << "\n";
-            } 
-        }
-        if(m.getAddress() == "/knobs") {
-            lua.setNumber("knob1", (float)m.getArgAsInt32(0) / 1023);
-            lua.setNumber("knob2", (float)m.getArgAsInt32(1) / 1023);
-            lua.setNumber("knob3", (float)m.getArgAsInt32(2) / 1023);
-            lua.setNumber("knob4", (float)m.getArgAsInt32(3) / 1023);
-            lua.setNumber("knob5", (float)m.getArgAsInt32(4) / 1023);
-        }
-        if(m.getAddress() == "/reload") {
-            cout << "reloading\n";
-            reloadScript();
-        }
+		if(message.status < MIDI_SYSEX) {
+			lua.setNumber(1, message.status);
+			lua.setNumber(2, message.channel);
+			lua.setNumber(3, message.pitch);
+			lua.setNumber(4, message.velocity);
+			lua.setNumber(5, message.control);
+			lua.setNumber(6, message.value);
+			lua.setNumber(7, message.portNum);
+			lua.setString(8, message.portName);
+			//lua.setNumber(9, message.deltatime);
+			//lua.setNumber(10, message.bytes);
+			lua.popTable();
+		}
+
+        //std::cout << "Pitch: " << midimes.pitch << std::endl;
+        midiMessages.pop();
     }
-    
-    // call the script's update() function
-    lua.scriptUpdate();
+
+	// check for waiting OSC messages
+	while(receiver.hasWaitingMessages()){
+		// get the next message
+		ofxOscMessage m;
+		receiver.getNextMessage(m);
+		//cout << "new message on port " << PORT << m.getAddress() << "\n";
+
+		// Additions for TouchOSC remote control
+		if(m.getAddress() == "/shift") {	
+			//cout << "shift" << "\n";
+			osdShiftSetting = !osdShiftSetting;
+			lua.setBool("osd_shift", osdShiftSetting);
+		}
+		if(m.getAddress() == "/key/1") {	
+			//cout << "osd" << "\n";
+			if (m.getArgAsInt32(0) == 1){
+				osdSetting = !osdSetting;
+                lua.setBool("osd_state", osdSetting);
+				if (osdShiftSetting && osdSetting) {
+					osdShiftSetting = false;
+					lua.setBool("osd_shift", osdShiftSetting);
+				}
+			}
+		}
+		if(m.getAddress() == "/key/3") {	
+			//cout << "change persist" << "\n";
+			persistSetting++;
+			persistSetting &= 1;
+			if (persistSetting == 1){
+				lua.setBool("persist", true);
+			}else{
+				lua.setBool("persist", false);
+			}
+		}
+		if(m.getAddress() == "/key/4") {	 
+			//cout << "back" << "\n";
+			prevScript();
+		}
+		if(m.getAddress() == "/key/5") {	 
+			//cout << "fwd" << "\n";
+			nextScript();
+		}
+		if(m.getAddress() == "/key/10") {	 
+			//cout << "trig" << "\n";
+			if (m.getArgAsInt32(0) == 1){
+				lua.setBool("trig", true);
+			}else{
+				lua.setBool("trig", false);
+			}
+		}
+		// EYESY Hardware
+		if(m.getAddress() == "/key") {	 
+			if (m.getArgAsInt32(0) == 1 && m.getArgAsInt32(1) > 0) {
+				// placeholder for OSD
+				//cout << "on screen display" << "\n";
+				osdSetting = !osdSetting;
+                lua.setBool("osd_state", osdSetting);
+			}
+			if (m.getArgAsInt32(0) == 2 && m.getArgAsInt32(1) > 0) {
+				// placeholder for shift
+				//cout << "shift" << "\n";
+				osdShiftSetting = !osdShiftSetting;
+				lua.setBool("osd_shift", osdShiftSetting);
+				
+			}
+			// mode selectors
+			if (m.getArgAsInt32(0) == 4 && m.getArgAsInt32(1) > 0) {
+				//cout << "back" << "\n";
+				prevScript();
+			}
+			if (m.getArgAsInt32(0) == 5 && m.getArgAsInt32(1) > 0) {
+				//cout << "fwd" << "\n";
+				nextScript();
+			}
+			// Scene selectors
+			if (m.getArgAsInt32(0) == 6 && m.getArgAsInt32(1) > 0) {
+				// placeholder for scene back
+			}
+			if (m.getArgAsInt32(0) == 7 && m.getArgAsInt32(1) > 0) {
+				// placeholder for scene forward
+			}
+			if (m.getArgAsInt32(0) == 8 && m.getArgAsInt32(1) > 0) {
+				// placeholder for scene save
+			}
+			if (m.getArgAsInt32(0) == 9 && m.getArgAsInt32(1) > 0) {
+				img.grabScreen(0,0,ofGetWidth(),ofGetHeight());
+				string fileName = "snapshot_"+ofToString(10000+snapCounter)+".png";
+				//cout << "saving " + fileName + "...";
+				img.save("/sdcard/Grabs/" + fileName);
+				//cout << "saved\n";
+				snapCounter++;
+			}
+			if (m.getArgAsInt32(0) == 3 && m.getArgAsInt32(1) > 0) {
+				//cout << "change persist" << "\n";
+				persistSetting++;
+				persistSetting &= 1;
+			}
+			if (m.getArgAsInt32(0) == 10 && m.getArgAsInt32(1) > 0) {
+				//cout << "trig" << "\n";
+				lua.setBool("trig", true);
+			} else if (m.getArgAsInt32(0) == 10 && m.getArgAsInt32(1) == 0) {
+				lua.setBool("trig", false);
+			}
+
+		}
+		// Additions for TouchOSC remote control
+		if(m.getAddress() == "/knobs/1") {
+			lua.setNumber("knob1", (float)m.getArgAsInt32(0) / 1023);
+			//printf("%lu knob1.\n", m.getArgAsInt32(0));
+		}
+		if(m.getAddress() == "/knobs/2") {
+			lua.setNumber("knob2", (float)m.getArgAsInt32(0) / 1023);
+		}
+		if(m.getAddress() == "/knobs/3") {
+			lua.setNumber("knob3", (float)m.getArgAsInt32(0) / 1023);
+		}
+		if(m.getAddress() == "/knobs/4") {
+			lua.setNumber("knob4", (float)m.getArgAsInt32(0) / 1023);
+		}
+		if(m.getAddress() == "/knobs/5") {
+			lua.setNumber("knob5", (float)m.getArgAsInt32(0) / 1023);
+		}
+		
+		// EYESY Hardware
+		if(m.getAddress() == "/knobs") {
+			lua.setNumber("knob1", (float)m.getArgAsInt32(0) / 1023);
+			lua.setNumber("knob2", (float)m.getArgAsInt32(1) / 1023);
+			lua.setNumber("knob3", (float)m.getArgAsInt32(2) / 1023);
+			lua.setNumber("knob4", (float)m.getArgAsInt32(3) / 1023);
+			lua.setNumber("knob5", (float)m.getArgAsInt32(4) / 1023);
+		}
+		if(m.getAddress() == "/reload") {
+			//cout << "reloading\n";
+			reloadScript();
+		}
+		if(m.getAddress() == "/ascale") {
+			//cout << "audio scale\n";
+			lua.setNumber("ascale", (float)m.getArgAsInt32(0) / 1023); // float 0 to 2 from osc
+		}
+		if(m.getAddress() == "/trigger_source") {
+			//cout << "trigger source\n";
+			lua.setNumber("trigsource", m.getArgAsInt32(0)); // 1 to 6 from osc
+		}
+		if(m.getAddress() == "/midi_ch") {
+			//cout << "midi channel\n";
+			lua.setNumber("midi_ch", m.getArgAsInt32(0)); // 1 to 16 from osc
+
+		}
+	}
+	
+	// call the script's update() function
+	lua.scriptUpdate();
 
 }
 
 //--------------------------------------------------------------
 void ofApp::draw() {
-    
-    lua.setNumberVector("inL", left);
-    lua.setNumberVector("inR", right);
-   
-    lua.scriptDraw();
- 
-    //ofDrawBitmapString(scripts[currentScript], 10, ofGetHeight()-10);
-    
-    // clear flags    
-    lua.setBool("trig", false);
+	
+	lua.setNumberVector("inL", left);
+	lua.setNumberVector("inR", right);
+	lua.setNumber("peak", peak);
+
+	lua.scriptDraw();
+	
+	//ofDrawBitmapString(scripts[currentScript], 10, ofGetHeight()-10);
+
+	// Clear flags	  
+	lua.setBool("trig", false);
 }
 
 //--------------------------------------------------------------
 void ofApp::audioIn(ofSoundBuffer & input){
-    
-    for (size_t i = 0; i < input.getNumFrames(); i++){
-        left[i]        = input[i*2]*0.5;
-        right[i]    = input[i*2+1]*0.5;
-    }
-    
-    bufferCounter++;
-    
+	
+	peak = 0.0;
+	
+	// samples are "interleaved"
+	//int numCounted = 0; 
+
+	for (size_t i = 0; i < input.getNumFrames(); i++){
+		left[i]		= input[i*2]*0.5;
+		right[i]	= input[i*2+1]*0.5;
+		if (left[i] > peak ) {
+			peak = left[i];
+		}
+	}
+	
+	bufferCounter++;
+	
 }
 
 //--------------------------------------------------------------
 void ofApp::exit() {
-    // call the script's exit() function
-    lua.scriptExit();
-    
-    // clear the lua state
-    lua.clear();
+	
+	// call the script's exit() function
+	lua.scriptExit();
+	
+	// clear the lua state
+	lua.clear();
+
+	// midi clean up
+	midiIn.closePort();
+	midiIn.removeListener(this);
+	
+	// GPIO cleanup
+	//gpio25.unexport_gpio();
+}
+
+//--------------------------------------------------------------
+void ofApp::newMidiMessage(ofxMidiMessage& msg) {
+
+	// add the latest message to the message queue
+	midiMessages.push(msg);
+
+
+		
+	// remove any old messages if we have too many
+ 
+	//while(midiMessages.size() > maxMessages) {
+
+	//	midiMessages.erase(midiMessages.begin());
+	//}
 }
 
 //--------------------------------------------------------------
 void ofApp::keyPressed(int key) {
-    
-    switch(key) {
-    
-        case 'r':
-            reloadScript();
-            break;
-    
-        case OF_KEY_LEFT:
-            prevScript();
-            break;
-            
-        case OF_KEY_RIGHT:
-            nextScript();
-            break;
-            
-        case ' ':
-            lua.doString("print(\"this is a lua string saying you hit the space bar!\")");
-            cout << "fps: " << ofGetFrameRate() << "\n";    
-            break;
-    }
-    
-    lua.scriptKeyPressed(key);
+	
+	switch(key) {
+		case '?':
+			midiIn.listInPorts();
+			break;
+
+		case 'r':
+			reloadScript();
+			break;
+	
+		case OF_KEY_LEFT:
+			prevScript();
+			break;
+			
+		case OF_KEY_RIGHT:
+			nextScript();
+			break;
+			
+		case ' ':
+			lua.doString("print(\"this is a lua string saying you hit the space bar!\")");
+			//cout << "fps: " << ofGetFrameRate() << "\n";	
+			break;
+	}
+	
+	lua.scriptKeyPressed(key);
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseMoved(int x, int y) {
-    lua.scriptMouseMoved(x, y);
+	lua.scriptMouseMoved(x, y);
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseDragged(int x, int y, int button) {
-    lua.scriptMouseDragged(x, y, button);
+	lua.scriptMouseDragged(x, y, button);
 }
 
 //--------------------------------------------------------------
 void ofApp::mousePressed(int x, int y, int button) {
-    lua.scriptMousePressed(x, y, button);
+	lua.scriptMousePressed(x, y, button);
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseReleased(int x, int y, int button) {
-    lua.scriptMouseReleased(x, y, button);
+	lua.scriptMouseReleased(x, y, button);
 }
 
 //--------------------------------------------------------------
 void ofApp::errorReceived(std::string& msg) {
-    ofLogNotice() << "got a script error: " << msg;
+	ofLogNotice() << "got a script error: " << msg;
 }
 
 //--------------------------------------------------------------
 void ofApp::reloadScript() {
-    // exit, reinit the lua state, and reload the current script
-    lua.scriptExit();
-    
-    // init OF
-    ofSetupScreen();
-    ofSetupGraphicDefaults();
-    ofSetBackgroundColor(0,0,0);
+	// exit, reinit the lua state, and reload the current script
+	lua.scriptExit();
+	
+	// init OF
+	ofSetupScreen();
+	ofSetupGraphicDefaults();
 
-    // load new
-    lua.init();
-    lua.doScript(scripts[currentScript], true);
-    lua.scriptSetup();
+	// load new
+	lua.init();
+	lua.doScript(scripts[currentScript]); //lua.doScript(scripts[currentScript], true);
+	lua.scriptSetup();
 }
 
 void ofApp::nextScript() {
-    currentScript++;
-    if(currentScript > scripts.size()-1) {
-        currentScript = 0;
-    }
-    reloadScript();
+	currentScript++;
+	if(currentScript > scripts.size()-1) {
+		currentScript = 0;
+	}
+	reloadScript();
 }
 
 void ofApp::prevScript() {
-    if(currentScript == 0) {
-        currentScript = scripts.size()-1;
-    }
-    else {
-        currentScript--;
-    }
-    reloadScript();
+	if(currentScript == 0) {
+		currentScript = scripts.size()-1;
+	}
+	else {
+		currentScript--;
+	}
+	reloadScript();
 }

--- a/src/ofApp.h
+++ b/src/ofApp.h
@@ -11,56 +11,78 @@
 #include "ofMain.h"
 #include "ofxLua.h"
 #include "ofxOsc.h"
+#include "ofxMidi.h"
+//#include "ofxGPIO.h"
+#include <queue>
 
 #define PORT 4000
 
-class ofApp : public ofBaseApp, ofxLuaListener {
+class ofApp : public ofBaseApp, ofxLuaListener, ofxMidiListener {
 
-    public:
+	public:
 
-        // main
-        void setup();
-        void update();
-        void draw();
-        void exit();
-        
-        // input
-        void keyPressed(int key);
-        void mouseMoved(int x, int y);
-        void mouseDragged(int x, int y, int button);
-        void mousePressed(int x, int y, int button);
-        void mouseReleased(int x, int y, int button);
-        
-        // ofxLua error callback
-        void errorReceived(std::string& msg);
-        
-        // script control
-        void reloadScript();
-        void nextScript();
-        void prevScript();
-    
-        ofxLua lua;
-        vector<string> scripts;
-        size_t currentScript;
+		// main
+		void setup();
+		void update();
+		void draw();
+		void exit();
+		
+		// input
+		void keyPressed(int key);
+		void mouseMoved(int x, int y);
+		void mouseDragged(int x, int y, int button);
+		void mousePressed(int x, int y, int button);
+		void mouseReleased(int x, int y, int button);
+		
+		// ofxLua error callback
+		void errorReceived(std::string& msg);
+		
+		// script control
+		void reloadScript();
+		void nextScript();
+		void prevScript();
+	
+		ofxLua lua;
+		vector<string> scripts;
+		size_t currentScript;
 
-        // osc control
-        ofxOscReceiver receiver;
+		// osc control
+		ofxOscReceiver receiver;
 
-        // audio stuff
-        void audioIn(ofSoundBuffer & input);
-    
-        vector <lua_Number> left;
-        vector <lua_Number> right;
+		// audio stuff
+		void audioIn(ofSoundBuffer & input);
 
-        int     bufferCounter;
-        int     drawCounter;
-    
-        float smoothedVol;
-        float scaledVol;
-        
-        ofSoundStream soundStream;
+		// MIDI In
+		void newMidiMessage(ofxMidiMessage& eventArgs);
+	
+		ofxMidiIn midiIn;
+		std::queue<ofxMidiMessage> midiMessages;
+		std::size_t maxMessages = 32; //< max number of messages to keep track of
+	
+		vector <lua_Number> left;
+		vector <lua_Number> right;
+		vector <float> volHistory;
+		
+		int 	bufferCounter;
+		int 	drawCounter;
+		
+		float smoothedVol;
+		float scaledVol;
+		float peak;
+		
+		ofSoundStream soundStream;
 
-        int                 snapCounter;
-        string              snapString;
-        ofImage             img;
+		int                 snapCounter;
+		string              snapString;
+		ofImage             img;
+	
+		ofFbo fbo;
+		int persistSetting;
+		bool osdSetting;
+		bool osdShiftSetting;
+		string modesPath;
+		string grabsPath;
+		
+		//GPIO gpio25;
+		//int state_button2;
 };


### PR DESCRIPTION
Here's my work in progress for ofLua implemetations of MIDI input and the On Screen Display. 

This is all bypassing pd altogether. So far I've been testing controlling with TouchOSC. If pd is running I'm not sure if there would be confusion of incoming MIDI messages.

I started to trying including ofxGPIO for knobs/buttons, but I had some conflicts on my device so I just left that alone for now and put some placeholders in the OF code.

The [ofxMidi](https://github.com/danomatika/ofxMidi) addon is required

The OSD and MIDI stuff is included from `eyesy.lua` and then just called from the mode script with a couple functions

`midi.knobs(midi_msg)` (in update())
and
`osd.osd_button (osd_state,osd_shift)` (in draw())

supplemental files for testing - these go in the EYESY engines/oflua directory
[lua.zip](https://github.com/owenosborn/ofEYESY/files/5632846/lua.zip)
[testMODES.zip](https://github.com/owenosborn/ofEYESY/files/5632845/testMODES.zip)

TouchOSC template
[EYESY-ipad2.touchosc.zip](https://github.com/owenosborn/ofEYESY/files/5632887/EYESY-ipad2.touchosc.zip)


There may be better ways to do some of this so I'm open to suggestions. :)

Curious note - I was able to get `ofSetBackgroundAuto(false);` to work on my pi4 build (buster 4.19.66-v7l+ and OF 0.11.0) and thus have persist working there - and it behaves like the python version which is nicer than the the previous `fbo` implementation. In playing with this I noticed some old OF and github posts on this, so it seems you all have been running up against this for awhile. I can't get ofxLua to properly compile on my Pi3b+ so can't confirm if this is working there and thus compatible with the CM3