### PR TITLE
Implement persistence button with FBO

### DIFF
--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -155,7 +155,9 @@ void ofApp::setup() {
     modeDescrip = lua.getString("modeExplain");
 
     thread.startThread();
-      
+
+    persistFbo.allocate(ofGetWindowWidth(), ofGetWindowHeight());
+
 }
 
 //--------------------------------------------------------------
@@ -200,7 +202,14 @@ void ofApp::update() {
 			dummyAudio = 0;
 			globalTrig = false;
 		}
-	    	
+
+		// persist toggle button
+		if (m.getArgAsInt32(0) == 3 && m.getArgAsInt32(1) > 0) {
+			persistEnabled = !persistEnabled;
+			persistFirstRender = true;
+			cout << "change persist: " << persistEnabled << "\n";
+		}
+
 		// osd toggle button
        	    	if (m.getArgAsInt32(0) == 1) {
 			osdEnabled = ( m.getArgAsInt32(1) > 0 ) ? true : false; 
@@ -374,6 +383,16 @@ void ofApp::update() {
 
 //--------------------------------------------------------------
 void ofApp::draw() {
+
+    // Re-draw background whenever persistence is disabled
+    if (persistEnabled) {
+        persistFbo.begin();
+        // Clear any remaining artifacts from GPU
+        if (persistFirstRender) {
+            persistFirstRender = false;
+            ofClear(255, 255, 255, 0);
+        }
+    }
     
     // set the audio buffer
     lua.setNumberVector("inL", left);
@@ -399,7 +418,12 @@ void ofApp::draw() {
 	ofTranslate( space, ceil( ofGetHeight() / 24 ) );
 	drawTheOsd();
    }
-    
+
+   if (persistEnabled) {
+        persistFbo.end();
+        persistFbo.draw(0,0);
+   }
+
 }
 
 //--------------------------------------------------------------

--- a/src/ofApp.h
+++ b/src/ofApp.h
@@ -108,10 +108,12 @@ class ofApp : public ofBaseApp, ofxLuaListener {
 	int 		totalScenes;
 	string 		osVersion;
 	ofxOscMessage 	mess;
-size_t 		sizeScripts;
+	size_t 		sizeScripts;
 	
-	
-	
+	// persistence stuff
+	bool		persistEnabled;
+	bool		persistFirstRender;
+	ofFbo		persistFbo;
 		
 	vector<int> 	osdMidi{0,0};
 	


### PR DESCRIPTION
Hi C&G,

Please accept this feature as a gift in return for a great device. I'm very interested in using my EYESY more and having 100% feature parity with the Pygame variety will make that more exciting!

Regarding this implementation, I actually first tried to use `ofSetBackgroundAuto`, and I ran into [this issue](https://github.com/openframeworks/openFrameworks/issues/5021), which of course was made by C&G. So I felt a little like I was following your footsteps here (especially with this oF [thread](https://forum.openframeworks.cc/t/ofsetbackgroundauto-false-not-working-on-raspberry-pi/16963/2)).

Here's a video of it in action on a particle system patch: https://user-images.githubusercontent.com/540290/172020610-dbe2c8af-142e-4a56-9d8c-a58de06e1d10.mp4

Let me know if you want anything changed in the PR.

-Brad